### PR TITLE
Restrict app icons to the same dimensions

### DIFF
--- a/app/src/main/res/layout/row.xml
+++ b/app/src/main/res/layout/row.xml
@@ -5,12 +5,12 @@
 
     <ImageView
         android:id="@+id/iconView"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:gravity="center"
-        android:padding="20dp"
+        android:layout_margin="20dp"
         android:src="@drawable/ic_ripple_trigger"/>
 
     <LinearLayout


### PR DESCRIPTION
Before:

![device-2018-01-25-104834](https://user-images.githubusercontent.com/244947/35389186-e0658996-01bd-11e8-9bb5-9bddddf845f0.png)

After:

![device-2018-01-25-104926](https://user-images.githubusercontent.com/244947/35389189-e68733e2-01bd-11e8-8e91-03d8406449f3.png)
