### PR TITLE
remove duplicated locale to unblock weblate component

### DIFF
--- a/metadata/no-NO/changelogs/75.txt
+++ b/metadata/no-NO/changelogs/75.txt
@@ -1,1 +1,0 @@
-Mange feilrettinger og en ny Ungarsk oversettelse

--- a/metadata/no-NO/short_description.txt
+++ b/metadata/no-NO/short_description.txt
@@ -1,1 +1,0 @@
-Utløs programmer for beskyttelse av ditt personvern i spente-/panikk-situasjoner

--- a/metadata/no-NO/title.txt
+++ b/metadata/no-NO/title.txt
@@ -1,1 +1,0 @@
-Ripple: Reager i nødsfall


### PR DESCRIPTION
the actual locale is nb, also for the app.

https://hosted.weblate.org/projects/guardianproject/ripple-metadata/ 